### PR TITLE
Added support for apache type paths e.g mysql-connector-java-5.1.22.jar 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 #Install to Project Repo
 A Python script for easily installing libraries to an in-project Maven repository. It creates a repository in the root folder of the project complete with poms, checksums and metadata. It also outputs the appropriate dependencies xml to be inserted in your `pom` file.
 
-
 ##What it does
 * When run in standard mode it looks for jars in the `lib` folder having name of Eclipse standard and ignores all files that don't match it. The Eclipse naming standard has the following format: 
 
@@ -26,6 +25,8 @@ After the script is complete copy-paste the generated dependencies xml to your `
     </repository>
 
 For more details please read [this StackOverflow answer](http://stackoverflow.com/a/7623805/485115).
+
+* This version was updated to support apache libraries formats e.g. mysql-connector-java-5.1.22.jar.  The --help option describes in more detail.  (Updated on 1/27/2012 by Stephen Boesch javadba@gmail.com)
 
 
 ##Example

--- a/apache-paths.diff
+++ b/apache-paths.diff
@@ -1,0 +1,67 @@
+25c25
+<     (name, version) = match.group(1, 2)
+---
+>     (libdir,name, version) = match.group(1, 2,3)
+42a43,80
+> # Matches pattern like [[/]a/b/c/]mysql-connector-java5-5.1.22.jar
+> #  and parses it to name=mysql-connector-java5  and version=5.1.22
+> #  i.e. there is an optional initial directory component that is handled
+> #  by a regex untion operator. The initial directory component is discarded by the regex
+> # btw the regex is more complicaed than should be due to python bug
+> #    http://stackoverflow.com/questions/3675144/regex-error-nothing-to-repeat
+> def parse_by_apache_standard(path,group):
+>   file = os.path.splitext(os.path.basename(path))[0]
+>   print " matching on file %s " % file
+>   #match = re.match("([\w\.\-/_])*?/?([\w\-\.]+?)-([\d\.]+).jar", file)
+>   #This version does not work with python match = re.match("(?:[\w\.\-/_]*)?/([\w\-\.]+?)-([\d\.]+).jar|([\w\-\.]+?)-([\d\.]+).jar", file)
+>   #match = re.match("(?:[\w\.\-/_])?/([\w\-\.]+?)-([\d\.]+)|([\w\-\.]+?)-([\d\.]+)", file)
+>   match = re.match("([\w\-\.]+?)-([\d\.]+)", file)
+>   if match != None:
+>     print "hi there"    
+>     (name, version) = match.group(1, 2)
+> 
+>     #name = name.split(".")
+>     source = False 
+>     #(group, name) = (".".join(name[:-2]), name[-2]) if source else (".".join(name[:-1]), name[-1])
+>     ix=name.find("-")
+>     if ix < 0:
+>         ix = 0
+>     if not group:
+>         group = name[0:ix]
+> 
+>     snapshot = version.upper().endswith(".SNAPSHOT")
+>     if snapshot:
+>       version = version[:-len(".snapshot")]
+> 
+>     return {
+>       "group": group,
+>       "name": name,
+>       "version": version,
+>       "snapshot": snapshot,
+>       "source": source
+>     }
+> 
+205a244,252
+> parser.add_option("-a", "--apache", 
+>                   dest="apache", action="store_true", default=False, 
+>                   help="Install files using apache jar standard eg. mysql-connector-java-5.1.22.jar. If you don't specify groupId (-g option) it will take the first string")
+> parser.add_option("-g", "--groupid", 
+>                   dest="groupid", action="store", default=False, 
+>                   help="Specify the groupId"),
+> parser.add_option("-l", "--libdir", 
+>                   dest="libdir", action="store", default="lib", 
+>                   help="Specify different directory containing the jar files (default is ./lib)")
+208c255
+< 
+---
+> libdir=options.libdir if options.libdir else "lib"
+210c257
+<   [(path, parse_interactively(path)) for path in jars("lib")]
+---
+>   [(path, parse_interactively(path)) for path in jars(libdir)]
+212c259,261
+<   [(path, parse_by_eclipse_standard(path)) for path in jars("lib")]
+---
+>   [(path, parse_by_apache_standard(path,options.groupid)) for path in jars(libdir)]
+>   if options.apache else
+>   [(path, parse_by_eclipse_standard(path)) for path in jars(libdir)]

--- a/install-to-project-repo.py
+++ b/install-to-project-repo.py
@@ -22,11 +22,49 @@ def parse_by_eclipse_standard(path):
   file = os.path.splitext(os.path.basename(path))[0]
   match = re.match("([\w\.]+)_(\d+\.\d+\.\d+.*)", file)
   if match != None:
-    (name, version) = match.group(1, 2)
+    (libdir,name, version) = match.group(1, 2,3)
 
     name = name.split(".")
     source = name[-1] == "source"
     (group, name) = (".".join(name[:-2]), name[-2]) if source else (".".join(name[:-1]), name[-1])
+
+    snapshot = version.upper().endswith(".SNAPSHOT")
+    if snapshot:
+      version = version[:-len(".snapshot")]
+
+    return {
+      "group": group,
+      "name": name,
+      "version": version,
+      "snapshot": snapshot,
+      "source": source
+    }
+
+# Matches pattern like [[/]a/b/c/]mysql-connector-java5-5.1.22.jar
+#  and parses it to name=mysql-connector-java5  and version=5.1.22
+#  i.e. there is an optional initial directory component that is handled
+#  by a regex untion operator. The initial directory component is discarded by the regex
+# btw the regex is more complicaed than should be due to python bug
+#    http://stackoverflow.com/questions/3675144/regex-error-nothing-to-repeat
+def parse_by_apache_standard(path,group):
+  file = os.path.splitext(os.path.basename(path))[0]
+  print " matching on file %s " % file
+  #match = re.match("([\w\.\-/_])*?/?([\w\-\.]+?)-([\d\.]+).jar", file)
+  #This version does not work with python match = re.match("(?:[\w\.\-/_]*)?/([\w\-\.]+?)-([\d\.]+).jar|([\w\-\.]+?)-([\d\.]+).jar", file)
+  #match = re.match("(?:[\w\.\-/_])?/([\w\-\.]+?)-([\d\.]+)|([\w\-\.]+?)-([\d\.]+)", file)
+  match = re.match("([\w\-\.]+?)-([\d\.]+)", file)
+  if match != None:
+    print "hi there"    
+    (name, version) = match.group(1, 2)
+
+    #name = name.split(".")
+    source = False 
+    #(group, name) = (".".join(name[:-2]), name[-2]) if source else (".".join(name[:-1]), name[-1])
+    ix=name.find("-")
+    if ix < 0:
+        ix = 0
+    if not group:
+        group = name[0:ix]
 
     snapshot = version.upper().endswith(".SNAPSHOT")
     if snapshot:
@@ -203,13 +241,24 @@ parser.add_option("-i", "--interactive",
 parser.add_option("-d", "--delete", 
                   dest="delete", action="store_true", default=False, 
                   help="Delete successfully installed libs in source location")
+parser.add_option("-a", "--apache", 
+                  dest="apache", action="store_true", default=False, 
+                  help="Install files using apache jar standard eg. mysql-connector-java-5.1.22.jar. If you don't specify groupId (-g option) it will take the first string")
+parser.add_option("-g", "--groupid", 
+                  dest="groupid", action="store", default=False, 
+                  help="Specify the groupId"),
+parser.add_option("-l", "--libdir", 
+                  dest="libdir", action="store", default="lib", 
+                  help="Specify different directory containing the jar files (default is ./lib)")
 (options, args) = parser.parse_args()
 
-
+libdir=options.libdir if options.libdir else "lib"
 parsings = (
-  [(path, parse_interactively(path)) for path in jars("lib")]
+  [(path, parse_interactively(path)) for path in jars(libdir)]
   if options.interactive else
-  [(path, parse_by_eclipse_standard(path)) for path in jars("lib")]
+  [(path, parse_by_apache_standard(path,options.groupid)) for path in jars(libdir)]
+  if options.apache else
+  [(path, parse_by_eclipse_standard(path)) for path in jars(libdir)]
 )
 
 unparsable_files = [r[0] for r in parsings if r[1] == None]


### PR DESCRIPTION
Hi Nikita,  i like your convenience script for local maven installs. However I do not use eclipse, it is useful for random jars.   The patch includes 3 new cmd line parameters, and have updated the README.md . 

take a look see if you want to include it, either way pls let me know what you decide/think.

stephen boesch  
